### PR TITLE
Build end-to-end data platform scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry config virtualenvs.create false
+          poetry install
+      - name: Lint
+        run: poetry run ruff check .
+      - name: Type check
+        run: poetry run mypy .
+      - name: Test
+        run: poetry run pytest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,125 @@
+# Modern Python Data Platform
+
+This repository contains a reference implementation of a modern, end-to-end data platform
+built with Python. It demonstrates how to combine an API layer, orchestration, asynchronous
+workers, a metrics warehouse, analytics dashboards, and CI/CD automation into a cohesive
+project that showcases quality and complexity.
+
+## Architecture Overview
+
+```
+FastAPI API  --->  DuckDB Warehouse  <---  Prefect ETL
+        |                         ^
+        |                         |
+   Celery Workers --------> Streamlit Dashboard
+```
+
+### API + Authentication Layer
+
+- FastAPI service exposes secured endpoints for ingesting metrics.
+- JWT-based authentication using OAuth2 password flow.
+- Structured logging and OpenTelemetry tracing out of the box.
+
+Run locally:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Retrieve a token:
+
+```bash
+curl -X POST "http://localhost:8000/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=data.engineer&password=changeme"
+```
+
+Ingest data:
+
+```bash
+curl -X POST "http://localhost:8000/ingest" \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"source": "cli", "metric": "demo", "value": 42.0}'
+```
+
+### Data Processing Pipeline
+
+- Prefect orchestrates ETL that fetches Bitcoin price data from Coindesk and loads it into DuckDB.
+- Resilient retry behavior with clear logging.
+
+Run the flow:
+
+```bash
+python -m pipelines.etl_flow
+```
+
+### Asynchronous Workers
+
+- Celery workers use Redis for the broker/backend and compute aggregated reports.
+- Flower can monitor the workers when launched with `celery -A worker.celery_app flower`.
+
+Start a worker locally:
+
+```bash
+celery -A worker.celery_app worker --loglevel=info
+```
+
+Trigger a task:
+
+```python
+from worker.celery_app import generate_summary
+result = generate_summary.delay("btc_price_usd")
+print(result.get(timeout=10))
+```
+
+### Analytics & Visualization
+
+- Streamlit dashboard renders tables, interactive Plotly charts, and anomaly alerts.
+
+Run the dashboard:
+
+```bash
+streamlit run dashboards/app.py
+```
+
+### CI/CD & Quality Gates
+
+- `pytest` for unit tests, `mypy` for static typing, and `ruff` for linting.
+- GitHub Actions workflow executes the quality gates on every push/PR.
+
+Run locally:
+
+```bash
+pytest
+mypy .
+ruff check .
+```
+
+### Documentation & Observability
+
+- Markdown docs in `docs/` with API overview.
+- Structured logging via `structlog` and tracing via OpenTelemetry console exporter.
+
+## Project Layout
+
+- `app/` – FastAPI service and authentication utilities.
+- `pipelines/` – Prefect ETL flow.
+- `worker/` – Celery application with analytic tasks.
+- `dashboards/` – Streamlit dashboard.
+- `docs/` – Additional documentation.
+- `tests/` – Automated tests with pytest.
+
+## Local Development
+
+1. Create a virtual environment and install dependencies (Poetry or `pip install -r`).
+2. Copy `.env.example` if you add one, set secrets.
+3. Run `uvicorn app.main:app --reload` to start the API.
+4. Launch supporting services (Redis, Prefect Orion, Streamlit) as needed.
+
+## Extending the Platform
+
+- Add more Prefect flows for upstream sources.
+- Integrate dbt for warehouse transformations.
+- Swap DuckDB for Snowflake or BigQuery by adapting connection logic.
+- Add Grafana dashboards backed by Prometheus metrics.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package for the demo data platform."""

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,98 @@
+"""Authentication utilities for the FastAPI service."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict, Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from .config import Settings, get_settings
+from .models import Token, TokenData, User, UserInDB
+
+# Demo user store; production systems should use a proper database
+_FAKE_USERS_DB: Dict[str, UserInDB] = {
+    "data.engineer": UserInDB(
+        username="data.engineer",
+        full_name="Data Engineer",
+        hashed_password=CryptContext(schemes=["bcrypt"]).hash("changeme"),
+    )
+}
+
+_oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+_pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a password against a hashed password."""
+
+    return _pwd_context.verify(plain_password, hashed_password)
+
+
+def get_user(username: str) -> Optional[UserInDB]:
+    """Retrieve a user from the in-memory store."""
+
+    return _FAKE_USERS_DB.get(username)
+
+
+def authenticate_user(username: str, password: str) -> Optional[UserInDB]:
+    """Authenticate username/password and return the user if valid."""
+
+    user = get_user(username)
+    if user is None or not verify_password(password, user.hashed_password):
+        return None
+    return user
+
+
+def create_access_token(data: dict, settings: Settings) -> str:
+    """Create a signed JWT access token."""
+
+    to_encode = data.copy()
+    expire = datetime.utcnow() + timedelta(minutes=settings.access_token_expire_minutes)
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
+
+async def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    settings: Settings = Depends(get_settings),
+) -> Token:
+    """OAuth2-compatible login endpoint."""
+
+    user = authenticate_user(form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    access_token = create_access_token({"sub": user.username}, settings=settings)
+    return Token(access_token=access_token)
+
+
+def get_current_user(
+    token: str = Depends(_oauth2_scheme),
+    settings: Settings = Depends(get_settings),
+) -> User:
+    """Resolve the user from a bearer token."""
+
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+        username: Optional[str] = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError as exc:  # pragma: no cover - error path
+        raise credentials_exception from exc
+    user = get_user(username)
+    if user is None:
+        raise credentials_exception
+    if user.disabled:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Inactive user")
+    return user

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,22 @@
+"""Configuration helpers for the FastAPI service."""
+from __future__ import annotations
+
+from functools import lru_cache
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """Runtime configuration derived from environment variables."""
+
+    jwt_secret_key: str = Field(default="super-secret", repr=False)
+    jwt_algorithm: str = "HS256"
+    access_token_expire_minutes: int = 60
+    duckdb_path: str = "data/warehouse.duckdb"
+    redis_url: str = "redis://localhost:6379/0"
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return cached settings instance."""
+
+    return Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,99 @@
+"""Main FastAPI application exposing secured ingestion endpoints."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import duckdb
+import structlog
+from fastapi import Depends, FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from opentelemetry import trace
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+from .auth import Token, get_current_user, login_for_access_token
+from .config import Settings, get_settings
+from .models import IngestionPayload, IngestionResponse, User
+
+logger = structlog.get_logger()
+
+app = FastAPI(title="Modern Data Platform API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.on_event("startup")
+async def _configure_tracing() -> None:
+    """Configure OpenTelemetry tracing when the app starts."""
+
+    provider = TracerProvider(
+        resource=Resource(attributes={SERVICE_NAME: "data-platform-api"})
+    )
+    provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+    trace.set_tracer_provider(provider)
+    FastAPIInstrumentor.instrument_app(app)
+    logger.info("tracing.initialized")
+
+
+@app.post("/token", response_model=Token)
+async def login(token: Token = Depends(login_for_access_token)) -> Token:
+    """Exchange credentials for a bearer token."""
+
+    logger.info("auth.login.success")
+    return token
+
+
+def _ensure_warehouse(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with duckdb.connect(str(path)) as conn:
+        conn.execute(
+            """
+            create table if not exists metrics (
+                source varchar,
+                metric varchar,
+                value double,
+                timestamp timestamp
+            )
+            """
+        )
+
+
+@app.post("/ingest", response_model=IngestionResponse)
+async def ingest(
+    payload: IngestionPayload,
+    user: User = Depends(get_current_user),
+    settings: Settings = Depends(get_settings),
+) -> IngestionResponse:
+    """Persist metrics into DuckDB and return metadata about the operation."""
+
+    logger.info("ingest.request", user=user.username, **payload.model_dump())
+    db_path = Path(settings.duckdb_path)
+    _ensure_warehouse(db_path)
+
+    with duckdb.connect(str(db_path)) as conn:
+        conn.execute(
+            "insert into metrics values (?, ?, ?, ?)",
+            (
+                payload.source,
+                payload.metric,
+                payload.value,
+                payload.timestamp,
+            ),
+        )
+    logger.info("ingest.persisted", warehouse=str(db_path))
+    return IngestionResponse(rows_ingested=1, warehouse_path=str(db_path))
+
+
+@app.get("/health", response_model=Dict[str, Any])
+async def health() -> Dict[str, Any]:
+    """Simple health-check endpoint."""
+
+    return {"status": "ok"}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,50 @@
+"""Pydantic models shared across the API."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class User(BaseModel):
+    """User representation used for authentication."""
+
+    username: str
+    full_name: str
+    disabled: bool = False
+
+
+class UserInDB(User):
+    """User model containing hashed password."""
+
+    hashed_password: str
+
+
+class Token(BaseModel):
+    """JWT token metadata."""
+
+    access_token: str
+    token_type: str = "bearer"
+
+
+class TokenData(BaseModel):
+    """Data encoded inside JWT tokens."""
+
+    username: Optional[str] = None
+
+
+class IngestionPayload(BaseModel):
+    """Input payload for data ingestion."""
+
+    source: str = Field(description="Name of the upstream data source")
+    metric: str = Field(description="Metric identifier", examples=["revenue"])
+    value: float = Field(description="Metric value in raw units")
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
+class IngestionResponse(BaseModel):
+    """Response describing persisted records."""
+
+    rows_ingested: int
+    warehouse_path: str

--- a/dashboards/app.py
+++ b/dashboards/app.py
@@ -1,0 +1,39 @@
+"""Streamlit dashboard visualizing metrics stored in DuckDB."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from app.config import get_settings
+
+st.set_page_config(page_title="Data Platform Analytics", layout="wide")
+st.title("Data Platform Metrics")
+
+settings = get_settings()
+warehouse_path = Path(settings.duckdb_path)
+
+if not warehouse_path.exists():
+    st.info("No data available yet. Run the ETL flow or ingest via the API.")
+else:
+    with duckdb.connect(str(warehouse_path)) as conn:
+        df = conn.execute("select * from metrics order by timestamp desc").fetch_df()
+    st.metric("Records", len(df))
+    st.dataframe(df, use_container_width=True)
+
+    if not df.empty:
+        trend = (
+            df.groupby(["metric", pd.Grouper(key="timestamp", freq="1H")])["value"].mean()
+            .reset_index()
+        )
+        fig = px.line(trend, x="timestamp", y="value", color="metric", title="Metric Trends")
+        st.plotly_chart(fig, use_container_width=True)
+
+        alerts = df[df["value"] > df["value"].mean() * 1.5]
+        if not alerts.empty:
+            st.warning("Anomaly detected for metrics: " + ", ".join(alerts["metric"].unique()))
+        else:
+            st.success("No anomalies detected")

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,14 @@
+# API Overview
+
+## Authentication
+
+Obtain a token by sending a POST request to `/token` with form fields `username` and `password`.
+Use the returned bearer token in the `Authorization` header for subsequent requests.
+
+## Endpoints
+
+### `POST /ingest`
+Ingest a metric payload into the DuckDB warehouse.
+
+### `GET /health`
+Check service health.

--- a/pipelines/etl_flow.py
+++ b/pipelines/etl_flow.py
@@ -1,0 +1,84 @@
+"""Prefect flow orchestrating data ingestion from a public API."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List
+
+import duckdb
+import httpx
+import pandas as pd
+from prefect import flow, get_run_logger, task
+
+from app.config import get_settings
+
+
+API_URL = "https://api.coindesk.com/v1/bpi/currentprice.json"
+
+
+@task(retries=3, retry_delay_seconds=10)
+def fetch_prices() -> pd.DataFrame:
+    """Fetch Bitcoin prices from Coindesk and return as DataFrame."""
+
+    response = httpx.get(API_URL, timeout=10.0)
+    response.raise_for_status()
+    payload = response.json()
+    rows: List[dict] = []
+    for currency, metadata in payload["bpi"].items():
+        rows.append(
+            {
+                "source": "coindesk",
+                "metric": f"btc_price_{currency.lower()}",
+                "value": float(metadata["rate_float"]),
+                "timestamp": datetime.utcnow(),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+@task
+def persist(df: pd.DataFrame) -> int:
+    """Persist DataFrame records into DuckDB."""
+
+    settings = get_settings()
+    path = Path(settings.duckdb_path)
+    path.parent.mkdir(exist_ok=True)
+    with duckdb.connect(str(path)) as conn:
+        conn.execute(
+            """
+            create table if not exists metrics (
+                source varchar,
+                metric varchar,
+                value double,
+                timestamp timestamp
+            )
+            """
+        )
+        conn.executemany(
+            "insert into metrics values (?, ?, ?, ?)",
+            cast_to_records(df.to_dict(orient="records")),
+        )
+    return len(df)
+
+
+def cast_to_records(rows: Iterable[dict]) -> List[tuple]:
+    """Convert DataFrame rows into tuples for DuckDB ingestion."""
+
+    return [
+        (row["source"], row["metric"], float(row["value"]), row["timestamp"]) for row in rows
+    ]
+
+
+@flow(name="bitcoin-price-etl")
+def etl_flow() -> int:
+    """End-to-end orchestration of the ETL job."""
+
+    logger = get_run_logger()
+    data = fetch_prices()
+    rows = persist(data)
+    logger.info("ETL completed", rows=rows)
+    return rows
+
+
+if __name__ == "__main__":
+    etl_flow()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[tool.poetry]
+name = "data-platform"
+version = "0.1.0"
+description = "End-to-end data platform example"
+authors = ["Example Developer <developer@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "^0.110.0"
+uvicorn = "^0.27.0"
+python-jose = "^3.3.0"
+passlib = {extras = ["bcrypt"], version = "^1.7.4"}
+structlog = "^24.1.0"
+opentelemetry-api = "^1.23.0"
+opentelemetry-sdk = "^1.23.0"
+opentelemetry-instrumentation-fastapi = "^0.44b0"
+httpx = "^0.27.0"
+prefect = "^2.14.0"
+pandas = "^2.2.0"
+duckdb = "^0.10.0"
+celery = "^5.3.6"
+redis = "^5.0.1"
+flower = "^2.0.1"
+streamlit = "^1.30.0"
+plotly = "^5.19.0"
+pyjwt = "^2.8.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4.0"
+pytest-asyncio = "^0.23.5"
+mypy = "^1.8.0"
+ruff = "^0.1.9"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+plugins = ["pydantic.mypy"]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,67 @@
+"""Tests for the FastAPI ingestion workflow."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import duckdb
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import _FAKE_USERS_DB, create_access_token
+from app.config import Settings
+from app.main import app
+from app.models import IngestionPayload
+
+
+@pytest.fixture(autouse=True)
+def _reset_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = Settings(duckdb_path=str(tmp_path / "warehouse.duckdb"))
+    monkeypatch.setattr("app.config.get_settings", lambda: settings)
+    Path(settings.duckdb_path).parent.mkdir(parents=True, exist_ok=True)
+    with duckdb.connect(settings.duckdb_path) as conn:
+        conn.execute(
+            """
+            create table if not exists metrics (
+                source varchar,
+                metric varchar,
+                value double,
+                timestamp timestamp
+            )
+            """
+        )
+
+
+def _token(settings: Settings) -> str:
+    user = next(iter(_FAKE_USERS_DB.values()))
+    return create_access_token({"sub": user.username}, settings)
+
+
+def test_healthcheck() -> None:
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_ingest_flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = Settings(duckdb_path=str(tmp_path / "warehouse.duckdb"))
+    monkeypatch.setattr("app.config.get_settings", lambda: settings)
+
+    payload = IngestionPayload(source="pytest", metric="unit", value=1.23, timestamp=datetime.utcnow())
+    client = TestClient(app)
+    token = _token(settings)
+    response = client.post(
+        "/ingest",
+        json=payload.model_dump(),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rows_ingested"] == 1
+    assert Path(body["warehouse_path"]).exists()
+
+    with duckdb.connect(settings.duckdb_path) as conn:
+        row = conn.execute("select * from metrics").fetchone()
+    assert row[0] == payload.source
+    assert row[1] == payload.metric

--- a/worker/celery_app.py
+++ b/worker/celery_app.py
@@ -1,0 +1,53 @@
+"""Celery application configured to run analytic workloads."""
+from __future__ import annotations
+
+import os
+
+from celery import Celery
+
+from app.config import get_settings
+
+settings = get_settings()
+
+celery_app = Celery(
+    "data_platform",
+    broker=os.environ.get("CELERY_BROKER_URL", settings.redis_url),
+    backend=os.environ.get("CELERY_RESULT_BACKEND", settings.redis_url),
+)
+celery_app.conf.task_track_started = True
+celery_app.conf.update(
+    task_serializer="json",
+    result_serializer="json",
+    accept_content=["json"],
+    timezone="UTC",
+    enable_utc=True,
+)
+
+
+@celery_app.task(name="reports.generate_summary")
+def generate_summary(metric: str) -> dict:
+    """Compute basic aggregates for a metric stored in DuckDB."""
+
+    from pathlib import Path
+
+    import duckdb
+
+    path = Path(settings.duckdb_path)
+    with duckdb.connect(str(path)) as conn:
+        result = conn.execute(
+            """
+            select metric, count(*) as records, avg(value) as average, max(timestamp) as last_seen
+            from metrics
+            where metric = ?
+            group by metric
+            """,
+            (metric,),
+        ).fetchone()
+    if result is None:
+        return {"metric": metric, "records": 0, "average": None, "last_seen": None}
+    return {
+        "metric": result[0],
+        "records": int(result[1]),
+        "average": float(result[2]),
+        "last_seen": result[3].isoformat() if result[3] else None,
+    }


### PR DESCRIPTION
## Summary
- implement FastAPI service with JWT auth, DuckDB persistence, and tracing
- add Prefect ETL flow, Celery analytics task, and Streamlit dashboard for analytics
- configure CI with pytest, mypy, ruff and provide documentation including README and API guide

## Testing
- not run (dependencies not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68e566d2872083289d7969f5032777b9